### PR TITLE
Hardcode serials

### DIFF
--- a/hpc-storage-sandbox-el7/Vagrantfile
+++ b/hpc-storage-sandbox-el7/Vagrantfile
@@ -111,6 +111,7 @@ __EOF"
 						"--size", "512",
 						"--format", "VDI",
 						"--variant", "fixed"]
+
 				end
 				if mds_idx==1 && not(File.exist?("#{vdisk_root}/mdt0.vdi"))
 					vbx.customize ["createmedium", "disk",
@@ -131,6 +132,11 @@ __EOF"
 					"--medium", "#{vdisk_root}/mgs.vdi",
 					"--mtype", "shareable",
 					"--device", "0"]
+				vbx.customize [
+					'setextradata', :id,
+					'VBoxInternal/Devices/ahci/0/Config/Port1/SerialNumber',
+					'MGS00000000000000000'
+				]
 				vbx.customize ["storageattach", :id,
 					"--storagectl", "SATA Controller",
 					"--port", "2",
@@ -138,6 +144,11 @@ __EOF"
 					"--medium", "#{vdisk_root}/mdt0.vdi",
 					"--mtype", "shareable",
 					"--device", "0"]
+				vbx.customize [
+					'setextradata', :id,
+					'VBoxInternal/Devices/ahci/0/Config/Port2/SerialNumber',
+					'MDT00000000000000000'
+				]
 			end
 			# Set host name of VM
 			mds.vm.host_name = "mds#{mds_idx}.lfs.local"
@@ -218,6 +229,11 @@ __EOF"
 						"--mtype", "shareable",
 						"--comment","OST%04d" % [osd]
 						]
+					vbx.customize [
+						'setextradata', :id,
+						"VBoxInternal/Devices/ahci/0/Config/Port#{pnum}/SerialNumber",
+						"OSTPORT#{pnum}".ljust(20, '0')
+					]
 				end
 			end
 


### PR DESCRIPTION
VBox disk serials are randomly generated. Instead, we can hardcode them to make the names deterministic, by doing this we can update the docs to be consistent, and eventually script the process.

<img width="1649" alt="screen shot 2017-10-20 at 9 26 59 pm" src="https://user-images.githubusercontent.com/458717/31846731-aa972422-b5dd-11e7-9114-c351101e6a10.png">
